### PR TITLE
Fix pillow compatibility, fix transparency handling

### DIFF
--- a/runescape_text/runescape_text.py
+++ b/runescape_text/runescape_text.py
@@ -1,10 +1,10 @@
-from PIL import Image, ImageDraw,ImageFont
+from PIL import Image, ImageDraw, ImageFont
 import math
 import sys, getopt, os
 
 # Preset colors
 black = (0,0,0,255)
-transparent = (255, 255, 255, 0)
+transparent = (0, 0, 0, 0)
 
 def get_size(font, text):
 	"""Get text size from getbbox, returns (width, height) like old getsize"""
@@ -52,42 +52,28 @@ def parse_string(input, delimiter=':', maxlen=80):
 		return effectmap[effect](input[:maxlen])
 
 def single_frame_save(img, file="out.png", append=""):
-	# img.save('test.gif', 'GIF', transparency=0)
 	# print("Save {}".format(file))
-	p = img.getpalette()
-	# First colour in palette is the bg, and should be transparent
-	tr = [p[0], p[1], p[2]]
-	img = img.convert("RGBA")
-	px = img.getdata()
-
-	newpx = []
-	for p in px:
-	    if p[0] == tr[0] and p[1] == tr[1] and p[2] == tr[2]:
-	        newpx.append((tr[0], tr[1], tr[2], 0))
-	    else:
-	        newpx.append(p)
-	img.putdata(newpx)
 	img.save(file, 'PNG')
 	return file
 
-def multi_frame_save(img_set, file="out.gif", frametime=100):
-	# print("Save {}".format(file))
-	img_set[0].save(
-		file,
-		'GIF', transparency=0,
-		append_images=img_set[1:],
-		save_all=True,
-		duration=frametime,
-		loop=0,
-		disposal=2,
-		optimize=False
-	)
-	return file
+def multi_frame_save(img_set, file="out.gif", frametime=100):	
+    # Transparency conversion done in save automatically
+    img_set[0].save(
+        file,
+        'GIF',
+        append_images=img_set[1:],
+        save_all=True,
+        duration=frametime,
+        loop=0,
+        disposal=2,
+        optimize=False
+    )
+    return file
 
 def no_effect(string):
 	if(advcolour=="none"):
 		size = get_size(fnt, string)
-		img = Image.new('P', (size[0], size[1]+4), transparent)
+		img = Image.new('RGBA', (size[0], size[1]+4), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		x = 0
@@ -100,7 +86,7 @@ def no_effect(string):
 		img_set=[]
 		frame = 0
 		while(frame < fps*4):
-			img = Image.new('P', (size[0], size[1]+4), transparent)
+			img = Image.new('RGBA', (size[0], size[1]+4), transparent)
 			draw = ImageDraw.Draw(img)
 			draw.fontmode = "1"
 			x = 0
@@ -118,7 +104,7 @@ def scroll_effect(string):
 	x_increment = max(round(size[0]/30), 3)
 	frame = 0
 	while(x_offset < (size[0]*2)+4):
-		img = Image.new('P', (size[0], size[1]+4), transparent)
+		img = Image.new('RGBA', (size[0], size[1]+4), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		x = size[0]+1-x_offset
@@ -141,7 +127,7 @@ def slide_effect(string):
 	y_increment = max(round(size[1]/10), 2)
 	frame = 0
 	while(y_offset < size[1]):
-		img = Image.new('P', (size[0], size[1]+4), transparent)
+		img = Image.new('RGBA', (size[0], size[1]+4), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		x = 0
@@ -156,7 +142,7 @@ def slide_effect(string):
 		y_offset=y_offset+y_increment
 		frame = frame+1
 	for i in range(1,11):
-		img = Image.new('P', (size[0], size[1]+4), transparent)
+		img = Image.new('RGBA', (size[0], size[1]+4), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		x = 0
@@ -170,7 +156,7 @@ def slide_effect(string):
 		img_set.append(img)
 		frame = frame+1
 	while(y_offset < (size[1]*2)+4):
-		img = Image.new('P', (size[0], size[1]+4), transparent)
+		img = Image.new('RGBA', (size[0], size[1]+4), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		x = 0
@@ -192,7 +178,7 @@ def wave_effect(string):
 	frames=20
 	amplitude = (size[1]/3)
 	for f in range(frames):
-		img = Image.new('P', (size[0]+(1*len(string)), round(size[1]+(amplitude*2)+0.5)), transparent)
+		img = Image.new('RGBA', (size[0]+(1*len(string)), round(size[1]+(amplitude*2)+0.5)), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		for i in range(len(string)):
@@ -217,7 +203,7 @@ def wave2_effect(string):
 	x_amplitude = size[0]/(len(string)*4)
 	y_amplitude = (size[1]/4)
 	for f in range(frames):
-		img = Image.new('P', (2+size[0]+(1*len(string)), round(size[1]+(y_amplitude*2)+0.5)), transparent)
+		img = Image.new('RGBA', (2+size[0]+(1*len(string)), round(size[1]+(y_amplitude*2)+0.5)), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		for i in range(len(string)):
@@ -239,7 +225,7 @@ def shake_effect(string):
 	frames=20
 	max_amplitude = size[1]/3
 	for f in range(frames):
-		img = Image.new('P', (size[0]+(1*len(string)), round(size[1]+(max_amplitude*2)+0.5)), transparent)
+		img = Image.new('RGBA', (size[0]+(1*len(string)), round(size[1]+(max_amplitude*2)+0.5)), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		for i in range(len(string)):
@@ -276,23 +262,23 @@ def flash2_colour(frame):
 	if(frame % fps*2 > fps):
 		return colourmap["cyan"]
 	else:
-		return (0,0,255)
+		return (0,0,255,255)
 def flash3_colour(frame):
 	if(frame % fps*2 > fps):
 		return colourmap["green"]
 	else:
-		return (0,255,0)
+		return (0,255,0,255)
 def glow1_colour(frame):
 	# red-orange-yellow-green-cyan
 	cycle_length = fps*2
 	inc = cycle_length/4
 	frame=frame%cycle_length
 	c_list = [
-		(255,0,0),
-		(255,128,0),
-		(255,255,0),
-		(0,128,0),
-		(0,255,255)
+		(255,0,0,255),
+		(255,128,0,255),
+		(255,255,0,255),
+		(0,128,0,255),
+		(0,255,255,255)
 	]
 	start_c = c_list[math.floor(frame/inc)]
 	end_c = c_list[1+math.floor(frame/inc)]
@@ -305,12 +291,12 @@ def glow2_colour(frame):
 	inc = cycle_length/5
 	frame=frame%cycle_length
 	c_list = [
-		(255,0,0),
-		(255,0,128),
-		(128,0,128),
-		(0,0,255),
-		(128,0,128),
-		(255,0,0)
+		(255,0,0,255),
+		(255,0,128,255),
+		(128,0,128,255),
+		(0,0,255,255),
+		(128,0,128,255),
+		(255,0,0,255)
 	]
 	start_c = c_list[math.floor(frame/inc)]
 	end_c = c_list[1+math.floor(frame/inc)]
@@ -323,12 +309,12 @@ def glow3_colour(frame):
 	inc = cycle_length/5
 	frame = frame%cycle_length
 	c_list = [
-		(255,255,255),
-		(0,255,0),
-		(0,128,0),
-		(0,255,0),
-		(255,255,255),
-		(0,255,255)
+		(255,255,255,255),
+		(0,255,0,255),
+		(0,128,0,255),
+		(0,255,0,255),
+		(255,255,255,255),
+		(0,255,255,255)
 	]
 	start_c = c_list[math.floor(frame/inc)]
 	end_c = c_list[1+math.floor(frame/inc)]
@@ -343,7 +329,8 @@ def calculate_gradient_pos(start, end, progress):
 	return (
 		start[0]+round(r_diff*progress),
 		start[1]+round(g_diff*progress),
-		start[2]+round(b_diff*progress)
+		start[2]+round(b_diff*progress),
+		255
 	)
 
 def line_merge(arr):
@@ -355,7 +342,7 @@ def line_merge(arr):
 		for frame in frames:
 			width=frame[0].size[0]+frame[1].size[0]
 			height=frame[0].size[1]+frame[1].size[1]
-			newframe = Image.new('P', (width, height), transparent)
+			newframe = Image.new('RGBA', (width, height), transparent)
 			newframe.paste(frame[0], (0,0))
 			newframe.paste(frame[1], (0,frame[0].size[1]))
 			mergedframes.append(newframe)
@@ -369,12 +356,12 @@ defaultadvcolour = "none"
 defaulteffect = "none"
 fps = 10
 colourmap = {
-	"yellow": (255,255,0),
-	"white": (255,255,255),
-	"cyan": (0,255,255),
-	"red": (255,0,0),
-	"green": (0,128,0),
-	"purple": (128,0,128)
+	"yellow": (255,255,0,255),
+	"white": (255,255,255,255),
+	"cyan": (0,255,255,255),
+	"red": (255,0,0,255),
+	"green": (0,128,0,255),
+	"purple": (128,0,128,255)
 }
 advcolourmap = {
 	"flash1": flash1_colour,

--- a/runescape_text/runescape_text.py
+++ b/runescape_text/runescape_text.py
@@ -6,6 +6,11 @@ import sys, getopt, os
 black = (0,0,0,255)
 transparent = (255, 255, 255, 0)
 
+def get_size(font, text):
+	"""Get text size from getbbox, returns (width, height) like old getsize"""
+	bbox = font.getbbox(text)
+	return (bbox[2] - bbox[0], bbox[3] - bbox[1])
+
 def parse_string(input, delimiter=':', maxlen=80):
 	global effect
 	global advcolour
@@ -81,7 +86,7 @@ def multi_frame_save(img_set, file="out.gif", frametime=100):
 
 def no_effect(string):
 	if(advcolour=="none"):
-		size = fnt.getsize(string)
+		size = get_size(fnt, string)
 		img = Image.new('P', (size[0], size[1]+4), transparent)
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
@@ -91,7 +96,7 @@ def no_effect(string):
 		draw.text((x,y), string, font=fnt, fill=colourmap[colour])
 		return [img]
 	else:
-		size = fnt.getsize(string)
+		size = get_size(fnt, string)
 		img_set=[]
 		frame = 0
 		while(frame < fps*4):
@@ -107,7 +112,7 @@ def no_effect(string):
 		return img_set
 
 def scroll_effect(string):
-	size = fnt.getsize(string)
+	size = get_size(fnt, string)
 	img_set=[]
 	x_offset = 0
 	x_increment = max(round(size[0]/30), 3)
@@ -130,7 +135,7 @@ def scroll_effect(string):
 	return img_set
 
 def slide_effect(string):
-	size = fnt.getsize(string)
+	size = get_size(fnt, string)
 	img_set=[]
 	y_offset = 0
 	y_increment = max(round(size[1]/10), 2)
@@ -182,7 +187,7 @@ def slide_effect(string):
 	return img_set
 	
 def wave_effect(string):
-	size = fnt.getsize(string)
+	size = get_size(fnt, string)
 	img_set=[]
 	frames=20
 	amplitude = (size[1]/3)
@@ -191,7 +196,7 @@ def wave_effect(string):
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		for i in range(len(string)):
-			x = fnt.getsize(string[:i])[0]+(1*i)
+			x = get_size(fnt, string[:i])[0]+(1*i)
 			wave = math.sin((((f+1)/(frames))*math.pi*2)+(i*(math.pi/6)))
 			y = amplitude + wave*amplitude
 			if(advcolour=="none"):
@@ -206,7 +211,7 @@ def wave_effect(string):
 	return img_set
 
 def wave2_effect(string):
-	size = fnt.getsize(string)
+	size = get_size(fnt, string)
 	img_set=[]
 	frames=20
 	x_amplitude = size[0]/(len(string)*4)
@@ -217,7 +222,7 @@ def wave2_effect(string):
 		draw.fontmode = "1"
 		for i in range(len(string)):
 			wave = math.sin((((f+1)/(frames))*math.pi*2)+(i*(math.pi/6)))
-			x = 2+fnt.getsize(string[:i])[0] +(1*i)- wave*x_amplitude
+			x = 2+get_size(fnt, string[:i])[0] +(1*i)- wave*x_amplitude
 			y = y_amplitude + wave*y_amplitude
 			if(advcolour=="none"):
 				draw.text((x+1,y+1), string[i], font=fnt, fill=black)
@@ -229,7 +234,7 @@ def wave2_effect(string):
 	return img_set
 
 def shake_effect(string):
-	size = fnt.getsize(string)
+	size = get_size(fnt, string)
 	img_set=[]
 	frames=20
 	max_amplitude = size[1]/3
@@ -238,7 +243,7 @@ def shake_effect(string):
 		draw = ImageDraw.Draw(img)
 		draw.fontmode = "1"
 		for i in range(len(string)):
-			x = fnt.getsize(string[:i])[0]+(1*i)
+			x = get_size(fnt, string[:i])[0]+(1*i)
 			amplitude = -max_amplitude
 			current_peak = (f/frames)*100
 			if i > current_peak:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
 	name="runescape-text",
-	version="1.1.0",
+	version="1.1.1",
 	author="Riley Lahd",
 	author_email="sircinnamon@gmail.com",
 	description="A program for generating runescape-chat-like images of text.",
@@ -20,7 +20,7 @@ setuptools.setup(
 	],
 	python_requires='>=3.6',
     install_requires=[
-        "pillow",
+        "pillow>=9.0.0",
     ],
     package_data={"":["data/runescape_uf.ttf"]},
 )


### PR DESCRIPTION
Love OSRS and love this ❤️ 
Adding some fixes since some stuff doesn't work anymore due to pillow

## Changes

* Bumps version to 1.1.1
* Ensure Pillow compatibility: pillow>=9.0.0 (fnt.getsize deprecated) 
* Resolves `ValueError: cannot add non-opaque RGBA color to RGB palette` when adding transparency to P mode images
  * Refactor to use RGBA mode instead of P mode when creating images
  * Allow Pillow to Image.save GIF plugin to handle transparency instead of hacky manual palette indexing
  (For RGBA images, Pillow checks for lowest alpha colour and designates palette index of that colour to transparency automatically)
  